### PR TITLE
トップページにGoogleフォントを設定

### DIFF
--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -12,13 +12,20 @@
       transform: translate(-50%, -50%);
       width: 100%;
       text-align: center;
-      font-size: 100rem;
+      font-size: 500rem;
       color: white;
 
       @media screen and (max-width: 767px) {
         font-size: 10rem;
       }
     }
+
+    .yuji-mai-regular {
+      font-family: "Yuji Mai", serif;
+      font-weight: 400;
+      font-style: normal;
+    }
+    
 }
 
 

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,5 +1,13 @@
+<head>
+ <link rel="preconnect" href="https://fonts.googleapis.com">
+ <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+ <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+Georgian:wght@600&family=Yuji+Mai&display=swap" rel="stylesheet">
+</head>
+
 <div class='top-wrapper'>
   <div class='top-inner-text'>
+   <div class='yuji-mai-regular'>
     <h1>凡事徹底</h1>
+   </div>
   </div>
 </div>


### PR DESCRIPTION
トップページのタイトルに華やかさを追加するためにGoogleフォントを追加