### PR TITLE
ファビコン設定

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <%= favicon_link_tag('凡事徹底.png') %>
     <title><%= content_for(:title) || "Myapp" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">


### PR DESCRIPTION
# 準備

ヘッダーのタグアイコンをファビコンに使用する

# assets/assets/images配下に格納済みの画像を読み込むコードを書く

すべてのレイアウトにおける**app/views/layouts/application.html.erb**にファビコン機能を読み込むコードを記述する
``````app/views/layouts/application.html.erb
<%= favicon_link_tag('凡事徹底.png') %>
``````

