### PR TITLE
フラッシュメッセージに閉じるタグを追加

### DIFF
--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,5 +1,6 @@
 <% flash.each do |message_type, message| %>
-    <div class="alert alert-<%= message_type %>">
-      <%= message %>
-    </div>
-  <% end %>
+  <div class="alert alert-<%= message_type %> alert-dismissible fade show" role="alert">
+    <%= message %>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  </div>
+<% end %>


### PR DESCRIPTION
# 実装理由
flashメッセージは次のアクションが動くまで消えないから

# flashメッセージが表示されているページで手動でflashメッセージを閉じることができる機能を追加
app/views/shared/_flash_message.html.erbのフラッシュメッセージのフォームにて閉じる機能を追加する
``````app/views/shared/_flash_message.html.erb
<div class="alert alert-<%= message_type %> alert-dismissible fade show" role="alert"> 
<-- alert-dismissibleは、アラートが閉じるボタンを持つことを示し、fade showはアニメーションを適用している -->
    <%= message %>
    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button> 
<--閉じる機能のボタン-->
  </div>
``````