### PR TITLE
掲示版一覧画面へのルーティング設定する

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
   get "login", to: "user_sessions#new"
   post "login", to: "user_sessions#create"
   delete "logout", to: "user_sessions#destroy"
+
+  resources :matches, only: %i[index]
 end
 
 # ●resources について


### PR DESCRIPTION
# **掲示版一覧画面へのルーティング設定する**

### **config/routes.rbに resources :matches, only: %i[index] を記載する**

config/routes.rbを以下のように編集
````Ruby
resources :matches, only: %i[index]
````
## ●resources について
resources メソッドは、Ruby on Railsのルーティングに広く使用され、特定のリソースに対して標準的なRESTfulルートを一括で生成する
例えば、resources :users と記述することで、ユーザーに関連する一連のルート（index, new, create, show, edit, update, destroy）が自動的に設定される
これにより、コントローラの各アクションがURLとHTTPメソッドに紐づけられ、CRUD操作のルーティングが容易になる