### PR TITLE
draperを導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem "rails-i18n", "~> 7.0.0"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
 
-gem 'draper'
+gem "draper"
 # デコレーター時に必要
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,8 @@ gem "rails-i18n", "~> 7.0.0"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
 
+gem 'draper'
+# デコレーター時に必要
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (7.2.2)
       activesupport (= 7.2.2)
+    activemodel-serializers-xml (1.0.3)
+      activemodel (>= 5.0.0.a)
+      activesupport (>= 5.0.0.a)
+      builder (~> 3.1)
     activerecord (7.2.2)
       activemodel (= 7.2.2)
       activesupport (= 7.2.2)
@@ -105,6 +109,13 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.5.1)
     docile (1.4.1)
+    draper (4.0.4)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
+      ruby2_keywords
     drb (2.2.1)
     erubi (1.13.0)
     factory_bot (6.5.0)
@@ -246,6 +257,8 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.11)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     rexml (3.3.9)
     rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
@@ -293,6 +306,7 @@ GEM
       rubocop-performance
       rubocop-rails
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     securerandom (0.3.2)
     selenium-webdriver (4.26.0)
@@ -362,6 +376,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  draper
   factory_bot_rails
   jbuilder
   jsbundling-rails


### PR DESCRIPTION
# 目的
デコレーターを導入する準備をする

# 対応方法
### Gemfileに gem 'draper'を記述する
Gemfileに gem 'draper'を記述して下記のコマンドでインストールする
````bash
docker compose run web bundle install
````
### Draper（ドレッパー）
Draperとは、Ruby on Railsで使うgemの一つ
Draperをインストールすると、デコレーターを作成できるようになり、ユーザーに表示するデータを整形・加工するための処理（ビューに関するロジック）をモデルから分離し、コードの保守性と読みやすさを向上させることができる